### PR TITLE
add dbt version constraints and update pkg version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,7 +3,8 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: 'entr_warehouse'
-version: '1.0.0'
+version: '0.1.0'
+require-dbt-version: [">=1.0.0", "<2.0.0"]
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.


### PR DESCRIPTION
This PR adds the minimum components necessary for making the entr_warehouse repo a dbt package. I followed just through step 2 in [this article](https://docs.getdbt.com/docs/guides/building-packages)