### PR TITLE
Fix/remove dqc models

### DIFF
--- a/models/marts/entr/fct_entr_plant_data.sql
+++ b/models/marts/entr/fct_entr_plant_data.sql
@@ -1,4 +1,4 @@
 with
-    entr_src as (select * from {{ ref('dqc_entr_plant_sample') }})
+    entr_src as (select * from {{ ref('stg_entr_plant_sample') }})
 
 select * from entr_src

--- a/models/marts/entr/fct_entr_wtg_scada.sql
+++ b/models/marts/entr/fct_entr_wtg_scada.sql
@@ -1,4 +1,4 @@
 with
-    entr_src as (select * from {{ ref('dqc_entr_scada_sample') }})
+    entr_src as (select * from {{ ref('stg_entr_scada_sample') }})
 
 select * from entr_src

--- a/models/staging/entr_sample_data/dqc_entr_plant_sample.sql
+++ b/models/staging/entr_sample_data/dqc_entr_plant_sample.sql
@@ -1,1 +1,0 @@
-select * from {{ref('stg_entr_plant_sample')}}

--- a/models/staging/entr_sample_data/dqc_entr_scada_sample.sql
+++ b/models/staging/entr_sample_data/dqc_entr_scada_sample.sql
@@ -1,1 +1,0 @@
-select * from {{ref('stg_entr_scada_sample')}}


### PR DESCRIPTION
this PR removes some unused data quality control (dqc_) models - we don't have standards solidified on incorporating data quality control logic, so these would likely just be a source of confusion at this point