### PR TITLE
Adding relevant warehouse changes from Sept. 2022 - Jan. 2023 from private fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The [ENTR Runtime](https://github.com/entralliance/entr_runtime) Docker image co
 The ENTR Runtime image contains pre-built models defined by the ENTR Warehouse based on open-source example data; however, for users wishing to bring their own data, the ENTR Warehouse supports setup of new sources from CSV and other Spark-readable file types by leveraging the [dbt-external-tables](https://github.com/dbt-labs/dbt-external-tables/tree/main) package from dbt-labs.
 * With a clone of this entr_warehouse project mounted to the ENTR Runtime, drop a copy of the file you'd like to process through the ENTR data model into the `data/` directory
 * Within the `models/staging/` directory, write out the source definition for the new file within a YML file in the staging directory using the [dbt-external-tables](https://github.com/dbt-labs/dbt-external-tables/tree/main) guides as needed
-    * Note: the new files can be added to any YML file in the `models` folder but must be mapped under the `entr_warehouse`:
+    * **Note**: the new files can be added to any YML file in the `models` folder but must be mapped under the `entr_warehouse`:
     ```yml
     sources:
       - name: entr_warehouse
@@ -39,13 +39,14 @@ The ENTR Runtime image contains pre-built models defined by the ENTR Warehouse b
 ### Transforming New Data to ENTR Standard Formats
 Once the new file is set as a source, you will need to transform the data into the standard ENTR fact table format - to build the dbt transformations, you'll need to define and map the dimensional components of the new data utilizing the standard ENTR dimension table formats.
 
+#### 1. (Optional) Create an Intermediate Model to Facilitate Table Reshaping
 * You'll likely notice that the initial step in the transformation of the example sources (files) is just performing type casting (see the examples within the models/staging/entr_sample_data/intermediate directory), e.g. the [int_entr_scada_sample__cast](https://github.com/entralliance/entr_warehouse/blob/main/models/staging/entr_sample_data/intermediate/int_entr_scada_sample__cast.sql) model, which just performs type casting on the raw data as a preliminary step
     * Prepares the data for reshaping/pivoting; we expect this will be a frequently necessary staging step for source files with tags corresponding to data types
     * Assignment of dimensional keys, e.g. [here](https://github.com/entralliance/entr_warehouse/blob/e3eeb3e693349a2a6297274d686ef7f884a5bc18/models/staging/entr_sample_data/intermediate/int_entr_era5_sample__cast.sql#L4-L5) - see below for further detail
 
 #### 2. Establish Link Between New Facts and Dimensions
 * For the assignment of dimensional foreign keys, which is required for all ENTR Warehouse fact tables in their current state, the ENTR dimensions must be extended. For example, if the data you're preparing is not from La Haute Borne, a new plant must be added as a record within the [seeds/seed_asset_plant](https://github.com/entralliance/entr_warehouse/blob/main/seeds/seed_asset_plant.csv) dbt CSV seed file in order for the transformations to run properly, and the same goes for the other dimensional data assignments.
-    * Note: not every field within the dimensions will be useful or used in analyses or transformations, so it may be ok to leave some blank to start depending on your use case
+    * **Note**: not every field within the dimensions will be useful or used in analyses or transformations, so it may be ok to leave some blank to start depending on your use case
 * In addition to extending the seeded ENTR dimensions, it may be useful or necessary to seed mapping files that are specific to a source to facilitate the translation of data into ENTR vernacular; we expect this to most commonly be done for mapping identifiers in the data you bring to ENTR tag IDs within the ENTR dimension
     * For example, the following files map the example 4 La Haute Borne example data sets' fields to ENTR tags. These tables are used to join on the ENTR tag IDs to the appropriate fields once the source table has been reshaped/unpivoted to have the original column names in a field
         * [seed_la_haute_borne_era5_tag_map](https://github.com/entralliance/entr_warehouse/blob/main/seeds/seed_la_haute_borne_era5_tag_map.csv)

--- a/README.md
+++ b/README.md
@@ -16,17 +16,35 @@ The [ENTR Runtime](https://github.com/entralliance/entr_runtime) Docker image co
 
 *Note:* the following steps require at least basic experience with building models in dbt.
 
+### Loading New Data from Files
 The ENTR Runtime image contains pre-built models defined by the ENTR Warehouse based on open-source example data; however, for users wishing to bring their own data, the ENTR Warehouse supports setup of new sources from CSV and other Spark-readable file types by leveraging the [dbt-external-tables](https://github.com/dbt-labs/dbt-external-tables/tree/main) package from dbt-labs.
 * With a clone of this entr_warehouse project mounted to the ENTR Runtime, drop a copy of the file you'd like to process through the ENTR data model into the `data/` directory
 * Within the `models/staging/` directory, write out the source definition for the new file within a YML file in the staging directory using the [dbt-external-tables](https://github.com/dbt-labs/dbt-external-tables/tree/main) guides as needed
-* Run `dbt run-operation stage_external_sources` to make the file available as a source relation in dbt from which you can start building further transformations
+    * Note: the new files can be added to any YML file in the `models` folder but must be mapped under the `entr_warehouse`:
+    ```yml
+    sources:
+      - name: entr_warehouse
+        tables:
+          - name: <new table name>
+            description: <description of new source table>
+            external:
+              location: '<path to data file withing the container>' # e.g. "/home/jovyan/src/entr_warehouse/data/la_haute_borne_plant_data_sample.csv" - this depends on where you've mounted the entr_warehouse dir in the container
+              using: csv # specify for different file types accordingly
+              options:
+                header: 'true' # optional but used with the ENTR sample data
+    ```
+* Run `dbt run-operation stage_external_sources` to make the file available as a table in the ENTR runtime Spark warehouse and as a source relation in dbt from which you can start building further transformations
 * See the four files within the `data/` folder and their corresponding source definitions within the [entr_sample_data.yml file](https://github.com/entralliance/entr_warehouse/blob/main/models/staging/entr_sample_data/entr_sample_data.yml) for examples
 
+### Transforming New Data to ENTR Standard Formats
 Once the new file is set as a source, you will need to transform the data into the standard ENTR fact table format - to build the dbt transformations, you'll need to define and map the dimensional components of the new data utilizing the standard ENTR dimension table formats.
-* You'll likely notice that the initial step in the transformation of the example sources (files) is just performing type casting (see the examples within the models/staging/entr_sample_data/intermediate directory), e.g. the [int_entr_scada_sample__cast](https://github.com/entralliance/entr_warehouse/blob/main/models/staging/entr_sample_data/intermediate/int_entr_scada_sample__cast.sql) model, which just performs type casting on the raw data as a perliminary step
-    * Preparation the data for reshaping/pivoting, which we expect will be a frequently necessary staging step
-    * Assignment of dimensional keys, e.g. in the [int_entr_era5_sample__cast](https://github.com/entralliance/entr_warehouse/blob/e3eeb3e693349a2a6297274d686ef7f884a5bc18/models/staging/entr_sample_data/intermediate/int_entr_era5_sample__cast.sql#L4-L5) model, which has hard-coded foreign keys to the ENTR Plant and Reanalysis Dataset dimensions. These keys mark the records as coming from the ERA5 (distinct from other reanalysis products like MERRA-2) and as pertaining to the La Haute Borne plant (distinct from other plants)
-* For the assignment of dimensional foreign keys, which is required for all ENTR Warehouse tables in their current state, the ENTR dimensions may need be extended. For example, if the data you're preparing is not from La Haute Borne, a new plant must be added as a record within the [seeds/seed_asset_plant](https://github.com/entralliance/entr_warehouse/blob/main/seeds/seed_asset_plant.csv) dbt CSV seed file in order for the transformations to run properly, and the same goes for the other dimensional data assignments.
+
+* You'll likely notice that the initial step in the transformation of the example sources (files) is just performing type casting (see the examples within the models/staging/entr_sample_data/intermediate directory), e.g. the [int_entr_scada_sample__cast](https://github.com/entralliance/entr_warehouse/blob/main/models/staging/entr_sample_data/intermediate/int_entr_scada_sample__cast.sql) model, which just performs type casting on the raw data as a preliminary step
+    * Prepares the data for reshaping/pivoting; we expect this will be a frequently necessary staging step for source files with tags corresponding to data types
+    * Assignment of dimensional keys, e.g. [here](https://github.com/entralliance/entr_warehouse/blob/e3eeb3e693349a2a6297274d686ef7f884a5bc18/models/staging/entr_sample_data/intermediate/int_entr_era5_sample__cast.sql#L4-L5) - see below for further detail
+
+#### 2. Establish Link Between New Facts and Dimensions
+* For the assignment of dimensional foreign keys, which is required for all ENTR Warehouse fact tables in their current state, the ENTR dimensions must be extended. For example, if the data you're preparing is not from La Haute Borne, a new plant must be added as a record within the [seeds/seed_asset_plant](https://github.com/entralliance/entr_warehouse/blob/main/seeds/seed_asset_plant.csv) dbt CSV seed file in order for the transformations to run properly, and the same goes for the other dimensional data assignments.
     * Note: not every field within the dimensions will be useful or used in analyses or transformations, so it may be ok to leave some blank to start depending on your use case
 * In addition to extending the seeded ENTR dimensions, it may be useful or necessary to seed mapping files that are specific to a source to facilitate the translation of data into ENTR vernacular; we expect this to most commonly be done for mapping identifiers in the data you bring to ENTR tag IDs within the ENTR dimension
     * For example, the following files map the example 4 La Haute Borne example data sets' fields to ENTR tags. These tables are used to join on the ENTR tag IDs to the appropriate fields once the source table has been reshaped/unpivoted to have the original column names in a field
@@ -35,13 +53,16 @@ Once the new file is set as a source, you will need to transform the data into t
         * [seed_la_haute_borne_scada_tag_map](https://github.com/entralliance/entr_warehouse/blob/main/seeds/seed_la_haute_borne_scada_tag_map.csv)
         * [seed_plant_data_tag_map](https://github.com/entralliance/entr_warehouse/blob/main/seeds/seed_plant_data_tag_map.csv)
     * **Note**: we don't yet have standards defined for creating new ENTR tags, but that functionality will be coming soon
+
+#### 3. Align Staging Model with Associated ENTR Fact Table Schema
 * Once all metadata about the new data from the newly loaded file is available, the last staging step is transforming the data into the relevant ENTR generic fact table schema, which can be found in this project's dbt docs, e.g. [fct_entr_wtg_scada](https://entralliance.github.io/entr_warehouse/#!/model/model.entr_warehouse.fct_entr_wtg_scada) for the generic wind turbine SCADA data fact table schema - the staging model [stg_entr_scada_sample](https://github.com/entralliance/entr_warehouse/blob/main/models/staging/entr_sample_data/stg_entr_scada_sample.sql) performs the final transformation on the example SCADA data from La Haute Borne to make it match the table schema of the fct_entr_wtg_scada model. The current generic ENTR fact tables are as follows:
     * [fct_entr_plant_data](https://entralliance.github.io/entr_warehouse/#!/model/model.entr_warehouse.fct_entr_plant_data)
     * [fct_entr_wtg_scada](https://entralliance.github.io/entr_warehouse/#!/model/model.entr_warehouse.fct_entr_wtg_scada)
     * [fct_entr_reanalysis_data](https://entralliance.github.io/entr_warehouse/#!/model/model.entr_warehouse.fct_entr_reanalysis_data)
         * **Note**: this model is a good example showing 2 staged data sets (the ERA5 and MERRA-2 La Haute Borne reanalysis data) flowing into the same generic ENTR fact table for guidance in the following step
-* Once a staging model has been created for your new source data that matches the associated generic ENTR fact table schema, you will just need to union that new staging model with the generic ENTR fact table ready to make the new data ready for consumption by ENTR-based applications. For example, see the [fct_entr_reanalysis_data](https://entralliance.github.io/entr_warehouse/#!/model/model.entr_warehouse.fct_entr_reanalysis_data) model, which unions the ERA5 and MERRA-2 reanalysis example data sets from 2 different staging models (associated with the 2 different example reanalysis data sources).
 
+#### 4. Add Newly Staged Data to ENTR Fact Table
+Once a staging model has been created for your new source data that matches the associated generic ENTR fact table schema, you will just need to union that new staging model with the generic ENTR fact table to make the new data ready for consumption by ENTR-based applications. The [fct_entr_reanalysis_data](https://entralliance.github.io/entr_warehouse/#!/model/model.entr_warehouse.fct_entr_reanalysis_data) shows how multiple staging models are combined in the generic ENTR reanalysis model.
 
 
 ## Resources

--- a/macros/utils/get_period.sql
+++ b/macros/utils/get_period.sql
@@ -1,0 +1,17 @@
+{% macro get_period(interval_s, output_col='interval_period') %}
+    case
+        when {{interval_s}} < 60 then 'second'
+        when {{interval_s}} > 60 and {{interval_s}} < 3600 and mod({{interval_s}},60) = 0 then 'minute'
+        when {{interval_s}} > 3600 and {{interval_s}} < 82800 and mod({{interval_s}},3600) = 0 then 'hour'
+        when {{interval_s}} in (82800, 86400, 90000) then 'day' -- day
+        when {{interval_s}} in (
+            2419200, -- 28 days
+            2505600, -- 29 days
+            2592000, -- 30 days
+            2678400, -- 31 days
+            2674800, -- 31 days - 1 hour (March "spring forward")
+            2595600 -- 30 days + 1 hour (November "fall back")
+            ) then 'month' -- month
+        else null -- let's just support the freqs above for now
+    end as {{output_col}}
+{% endmacro %}

--- a/models/marts/entr/entr.yml
+++ b/models/marts/entr/entr.yml
@@ -1,0 +1,11 @@
+version: 2
+
+models:
+  - name: fct_entr_plant_data
+    description: generic ENTR fact table containing plant-level information
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - plant_id
+            - date_time
+            - entr_tag_id

--- a/models/marts/entr/fct_entr_wtg_scada.sql
+++ b/models/marts/entr/fct_entr_wtg_scada.sql
@@ -1,3 +1,5 @@
+{{config(materialized='table')}}
+
 with
     entr_src as (select * from {{ ref('stg_entr_scada_sample') }})
 

--- a/models/marts/exposures/openoa/intermediate/int_openoa_plant_data__resampled.sql
+++ b/models/marts/exposures/openoa/intermediate/int_openoa_plant_data__resampled.sql
@@ -1,0 +1,41 @@
+{{config(materialized='table')}}
+{% set src_model = 'fct_entr_plant_data' %}
+
+with
+    src as (select * from {{ ref('fct_entr_plant_data') }}),
+    plant_dim as (select * from {{ ref('dim_asset_wind_plant') }}),
+    tag_dim as (select * from {{ ref('dim_entr_tag_list') }}),
+
+    src_filt as (
+        select * from src
+        where entr_tag_id in (2554,2553,2555)
+    ),
+
+    period_maxs as (
+        select
+            plant_id,
+            {{get_period('max(interval_s)', output_col='max_period')}}
+        from src_filt
+        group by plant_id
+    ),
+
+    downsample as (
+        select
+            plant_id,
+            entr_tag_id,
+            value_type,
+            value_units,
+            date_trunc(period_maxs.max_period, date_time) as date_time,
+            sum(tag_value) as tag_value
+        from src_filt
+        left join period_maxs using(plant_id)
+        group by 1,2,3,4,5
+    )
+
+select
+    plant_dim.plant_name,
+    tag_dim.entr_tag_name,
+    downsample.*
+from downsample
+left join plant_dim using(plant_id)
+left join tag_dim using(entr_tag_id)

--- a/models/marts/exposures/openoa/openoa_curtailment_and_availability.sql
+++ b/models/marts/exposures/openoa/openoa_curtailment_and_availability.sql
@@ -1,4 +1,4 @@
-{% set src_model = 'int_openoa_plant_curtail_avail_data__filtered' %}
+{% set src_model = 'int_openoa_plant_data__resampled' %}
 
 with
     src as (select * from {{ ref(src_model) }})
@@ -17,4 +17,5 @@ select
             quote_identifiers = true) 
     }}
 from src
+where entr_tag_id in (2553, 2555)
 {{ dbt_utils.group_by(n=3) }}

--- a/models/staging/entr_sample_data/entr_sample_data.yml
+++ b/models/staging/entr_sample_data/entr_sample_data.yml
@@ -1,7 +1,5 @@
 version: 2
 
-version: 2
-
 sources:
   - name: entr_warehouse
     tables:

--- a/seeds/seed_entr_tag_list.csv
+++ b/seeds/seed_entr_tag_list.csv
@@ -2561,3 +2561,6 @@ entr_tag_id,entr_tag_name,logical_node,sensor_name,presentation_name,standard_un
 2560,WMETR.EnvTmp,WMETR.,EnvTmp,Reanalysis ambient temperature,°C,,,
 2561,WMETR.EnvPres,WMETR.,EnvPres,Reanalysis barometric pressure,bar,,,
 2562,WMETR.AirDen,WMETR.,AirDen,Reanalysis air density,kg/m³,,,
+2563,IAVL.ExtPwrDnW,IAVL.,ExtPwrDnW,Plant-level lost power due to curtailment,W,,,
+2564,WAPC.PsblWh,WAPC.,PsblWh,UPC Possible Active Energy,Wh,,,
+2565,IAVL.CurtailmentDispatchSignal,IAVL.,CurtailmentDispatchSignal,Curtailment dispatch signal from balancing entity,,,,


### PR DESCRIPTION
This pull request adds relevant changes made to the entr_warehouse since the release of v0.0.1 in August 2022. These changes were made on Lewis' private fork, which also contains proprietary data. To address this, this branch contains the relevant nonproprietary changes to the warehouse. 

Note: all code contributions in this PR were originally written by @lewisarmistead 

Major contributions consist of the following:

- Improvements to README file to clarify process for adding data for new wind plants
- A macro for identifying the sampling period of time series data (second, minute, hour, day, month) based on the number of seconds in the period
- A model to downsample plant availability and curtailment data in the open exposure to the lowest frequency provided
- Testing for primary key uniqueness of plant data
- Including a few additional curtailment-related tags to the ENTR tag list