### PR TITLE
Fix/pyentr targets materializations

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -45,6 +45,20 @@ clean-targets:         # directories to be removed by `dbt clean`
 # as tables. These settings can be overridden in the individual model files
 # using the `{{ config(...) }}` macro.
 models:
-  entr_warehouse:
-    marts:
-      +materialized: view
+  openoa:
+    generic_openoa_tables:
+      dim_asset_wind_turbine:
+        +materialized: table
+      dim_asset_wind_plant:
+        +materialized: table
+      dim_asset_wind_turbine:
+        +materialized: table
+    exposures:
+      openoa_curtailment_and_availability:
+        +materialized: table
+      openoa_reanalysis:
+        +materialized: table
+      openoa_revenue_meter:
+        +materialized: table
+      openoa_wtg_scada:
+        +materialized: table

--- a/packages.yml
+++ b/packages.yml
@@ -2,7 +2,7 @@ packages:
   - package: dbt-labs/spark_utils
     version: [">=0.3.0", "<0.4.0"]
   - git: "https://github.com/entralliance/dbt-openoa.git"
-    revision: "dev"
+    revision: "0.0.3"
   - package: calogica/dbt_date
     version: [">=0.7.0", "<0.8.0"]
   - package: dbt-labs/dbt_external_tables


### PR DESCRIPTION
@jordanperr - I updated the materialization types for the models I found in the [plantdata module](https://github.com/entralliance/py-entr/blob/main/entr/plantdata.py) in py-entr. Let me know if there are others that need changing - alternatively, you can update them directly following a similar pattern to the one I used (see changes to the `dbt_project.yml`)

I went ahead and pinned the dbt-openoa package version in this PR as well.

Fixes #27 