### PR TITLE
Fix/package versions and latlon fix

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -2,7 +2,7 @@ packages:
   - package: dbt-labs/spark_utils
     version: [">=0.3.0", "<0.4.0"]
   - git: "https://github.com/entralliance/dbt-openoa.git"
-    revision: "0.0.3"
+    revision: 0.0.4
   - package: calogica/dbt_date
     version: [">=0.7.0", "<0.8.0"]
   - package: dbt-labs/dbt_external_tables

--- a/seeds/seed_asset_plant.csv
+++ b/seeds/seed_asset_plant.csv
@@ -1,2 +1,2 @@
 asset_id,asset_type,asset_name,latitude,longitude,plant_capacity,number_of_turbines,turbine_capacity
-1,plant,La Haute Borne,48.452,5.588,8.2,4,2.05
+1,plant,La Haute Borne,48.4497,5.5896,8.2,4,2.05


### PR DESCRIPTION
This PR pins the package version of dbt-openoa used to create a necessary level of stability in this example project.

This also fixes an error identified in #28 - the lat/lon numbers used for La Haute did not match those used in OpenOA.

Fixes #28 